### PR TITLE
Improved: in fav productStore and shopifyShop, added check for valid userLoginId(#201)

### DIFF
--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -354,7 +354,7 @@
           </ion-card-content>
             <ion-list>
               <ion-item>
-                <ion-select :label="translate('Product store')" interface="popover" :value="selectedUser.favoriteProductStorePref?.userPrefValue ? selectedUser.favoriteProductStorePref?.userPrefValue : ''" @ionChange="updateFavoriteProductStore($event)">
+                <ion-select :label="translate('Product store')" interface="popover" :value="selectedUser.favoriteProductStorePref?.userPrefValue ? selectedUser.favoriteProductStorePref?.userPrefValue : ''" @ionChange="updateFavoriteProductStore($event)" :disabled="selectedUser?.userLoginId === null">
                   <ion-select-option v-for="productStore in productStores" :key="productStore.productStoreId" :value="productStore.productStoreId">
                     {{ productStore.storeName }}
                   </ion-select-option>

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -354,7 +354,7 @@
           </ion-card-content>
             <ion-list>
               <ion-item>
-                <ion-select :label="translate('Product store')" interface="popover" :value="selectedUser.favoriteProductStorePref?.userPrefValue ? selectedUser.favoriteProductStorePref?.userPrefValue : ''" @ionChange="updateFavoriteProductStore($event)" :disabled="selectedUser?.userLoginId === null">
+                <ion-select :label="translate('Product store')" interface="popover" :value="selectedUser.favoriteProductStorePref?.userPrefValue ? selectedUser.favoriteProductStorePref?.userPrefValue : ''" @ionChange="updateFavoriteProductStore($event)" :disabled="!selectedUser?.userLoginId">
                   <ion-select-option v-for="productStore in productStores" :key="productStore.productStoreId" :value="productStore.productStoreId">
                     {{ productStore.storeName }}
                   </ion-select-option>

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -362,7 +362,7 @@
                 </ion-select>
               </ion-item>
               <ion-item lines="none">
-                <ion-select :label="translate('Shopify shop')" interface="popover" :value="selectedUser.favoriteShopifyShopPref?.userPrefValue ? selectedUser.favoriteShopifyShopPref?.userPrefValue : ''" @ionChange="updateFavoriteShopifyShop($event)">
+                <ion-select :label="translate('Shopify shop')" interface="popover" :value="selectedUser.favoriteShopifyShopPref?.userPrefValue ? selectedUser.favoriteShopifyShopPref?.userPrefValue : ''" @ionChange="updateFavoriteShopifyShop($event)" :disabled="!selectedUser?.userLoginId">
                   <ion-select-option v-for="shopifyShop in shopifyShopsForProductStore" :key="shopifyShop.shopId" :value="shopifyShop.shopId">
                     {{ shopifyShop.name }}
                   </ion-select-option>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#201 
### Short Description and Why It's Useful
- Disabled the selection of the Favorite ProductStore on UI when user is not fully authentiacted.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)