### PR TITLE
Improved: Display IDs for Security Group and Product Store(#199)

### DIFF
--- a/src/components/FilterMenu.vue
+++ b/src/components/FilterMenu.vue
@@ -12,7 +12,7 @@
           <ion-icon :icon="idCardOutline" slot="start" />
           <ion-select :label="translate('Clearance')" interface="popover" v-model="query.securityGroup" @ionChange="closeMenu">
             <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-            <ion-select-option :value="securityGroup.groupId" :key="index" v-for="(securityGroup, index) in securityGroups">{{ securityGroup.groupName }}</ion-select-option>
+            <ion-select-option :value="securityGroup.groupId" :key="index" v-for="(securityGroup, index) in securityGroups">{{ securityGroup.groupName || securityGroup.groupId }}</ion-select-option>
           </ion-select>
         </ion-item>
         <ion-item lines="none">

--- a/src/components/PermissionItems.vue
+++ b/src/components/PermissionItems.vue
@@ -13,7 +13,7 @@
     <div v-for="(group, groupId) in filteredPermissions" :key="groupId">
       <ion-item-divider v-if="group.permissions.length" class="ion-margin-vertical" color="light">
         <ion-label>
-          {{ group.groupName }}
+          {{ group.groupName || group.groupId }}
         </ion-label>
       </ion-item-divider>
 

--- a/src/components/ProductStoreActionsPopover.vue
+++ b/src/components/ProductStoreActionsPopover.vue
@@ -1,7 +1,7 @@
 <template>
   <ion-content>
     <ion-list>
-      <ion-list-header>{{ productStore.storeName }}</ion-list-header>
+      <ion-list-header>{{ productStore.storeName || productStore.productStoreId }}</ion-list-header>
       <ion-item button @click="selectProductStoreRole()">
         {{ translate("Edit") }}
       </ion-item>

--- a/src/components/SelectFacilityModal.vue
+++ b/src/components/SelectFacilityModal.vue
@@ -15,7 +15,7 @@
       <ion-item v-for="facility in facilities" :key="facility.facilityId">
         <ion-checkbox :checked="isSelected(facility.facilityId)" @ionChange="toggleFacilitySelection(facility)">
           <ion-label>
-            {{ facility.facilityName }}
+            {{ facility.facilityName || facility.facilityId }}
             <p>{{ facility.facilityId }}</p>
           </ion-label>
         </ion-checkbox>
@@ -27,7 +27,7 @@
         <ion-item v-for="facility in facilities" :key="facility.facilityId">
           <ion-radio :value="facility.facilityId">
             <ion-label>
-              {{ facility.facilityName }}
+              {{ facility.facilityName || facility.facilityId }}
               <p>{{ facility.facilityId }}</p>
             </ion-label>
           </ion-radio>

--- a/src/components/SelectProductStoreModal.vue
+++ b/src/components/SelectProductStoreModal.vue
@@ -15,7 +15,7 @@
       <ion-item v-for="productStore in productStores" :key="productStore.productStoreId">
         <ion-checkbox :checked="isSelected(productStore.productStoreId)" @ionChange="toggleProductStoreSelection(productStore)">
           <ion-label>
-            {{ productStore.storeName }}
+            {{ productStore.storeName || productStore.productStoreId }}
             <p>{{ productStore.productStoreId }}</p>
           </ion-label>
         </ion-checkbox>

--- a/src/views/CreateUser.vue
+++ b/src/views/CreateUser.vue
@@ -18,7 +18,7 @@
             <ion-icon slot="start" :icon="businessOutline"/>
             <ion-select interface="popover" v-model="formData.facilityId" @ionChange="updateGroupName">
               <div slot="label">{{ translate("Select facility") }} <ion-text color="danger">*</ion-text></div>
-              <ion-select-option v-for="facility in (facilities ? facilities : [])" :key="facility.facilityId" :value="facility.facilityId">{{ facility.facilityName }}</ion-select-option>
+              <ion-select-option v-for="facility in (facilities ? facilities : [])" :key="facility.facilityId" :value="facility.facilityId">{{ facility.facilityName || facility.facilityId }}</ion-select-option>
             </ion-select>
           </ion-item>
           <ion-item>

--- a/src/views/Permissions.vue
+++ b/src/views/Permissions.vue
@@ -20,8 +20,8 @@
             <ion-item v-for="group in securityGroups" :key="group?.groupId" button detail @click="updateCurrentGroup(group)">
               <ion-label :color="group.groupId === currentGroup?.groupId ? 'primary' : ''">
                 <p class="overline">{{ group.groupId }}</p>
-                {{ group?.groupName }}
-              </ion-label>
+                {{ group?.groupName || group?.groupId }}
+              </ion-label> 
             </ion-item>
           </ion-list>
 
@@ -36,7 +36,7 @@
               <ion-icon :icon="idCardOutline" slot="start" />
               <ion-label>
                 <ion-note class="overline">{{ currentGroup.groupId }}</ion-note>
-                <h1>{{ currentGroup.groupName }}</h1>
+                <h1>{{ currentGroup.groupName || currentGroup.groupId }}</h1>
                 <p class="ion-text-wrap">{{ currentGroup.description }}</p>
               </ion-label>
               <ion-button slot="end" @click="editSecurityGroup()" fill="outline">{{ translate("Edit") }}</ion-button>

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -265,7 +265,7 @@
               </template>
               <ion-select v-else :label="translate('Security Group')" interface="popover" :disabled="!hasPermission(Actions.APP_SECURITY_GROUP_CREATE) || !selectedUser.userLoginId" :value="selectedUser.securityGroup?.groupId" @ionChange="updateSecurityGroup($event)">
                 <ion-select-option v-for="securityGroup in getSecurityGroups(securityGroups)" :key="securityGroup.groupId" :value="securityGroup.groupId">
-                  {{ securityGroup.groupName }}
+                  {{ securityGroup.groupName || securityGroup.groupId}}
                 </ion-select-option>
                 <ion-select-option value="">{{ translate("None") }}</ion-select-option>
               </ion-select>
@@ -284,7 +284,7 @@
               </ion-list-header>
               <ion-item :disabled="!hasPermission(Actions.APP_UPDT_PRODUCT_STORE_CONFG)" v-for="store in userProductStores" :key="store.productStoreId">
                 <ion-label>
-                  <h2>{{ store.storeName }}</h2>
+                  <h2>{{ store.storeName || store.productStoreId }}</h2>
                   <p>{{ getRoleTypeDesc(store.roleTypeId) }}</p>
                 </ion-label>
                 <ion-button slot="end" fill="clear" color="medium" @click="openProductStoreActionsPopover($event, store)">

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -356,7 +356,7 @@
               <ion-item>
                 <ion-select :label="translate('Product store')" interface="popover" :value="selectedUser.favoriteProductStorePref?.userPrefValue ? selectedUser.favoriteProductStorePref?.userPrefValue : ''" @ionChange="updateFavoriteProductStore($event)">
                   <ion-select-option v-for="productStore in productStores" :key="productStore.productStoreId" :value="productStore.productStoreId">
-                    {{ productStore.storeName }}
+                    {{ productStore.storeName || productStore.productStoreId}}
                   </ion-select-option>
                   <ion-select-option value="">{{ translate("None") }}</ion-select-option>
                 </ion-select>
@@ -364,7 +364,7 @@
               <ion-item lines="none">
                 <ion-select :label="translate('Shopify shop')" interface="popover" :value="selectedUser.favoriteShopifyShopPref?.userPrefValue ? selectedUser.favoriteShopifyShopPref?.userPrefValue : ''" @ionChange="updateFavoriteShopifyShop($event)">
                   <ion-select-option v-for="shopifyShop in shopifyShopsForProductStore" :key="shopifyShop.shopId" :value="shopifyShop.shopId">
-                    {{ shopifyShop.name }}
+                    {{ shopifyShop.name || shopifyShop.shopId }}
                   </ion-select-option>
                   <ion-select-option value="">{{ translate("None") }}</ion-select-option>
                 </ion-select>

--- a/src/views/UserQuickSetup.vue
+++ b/src/views/UserQuickSetup.vue
@@ -73,12 +73,12 @@
           <ion-item v-for="facility in facilities" :key="facility.facilityId">
             <ion-checkbox v-if="!isFacilityLogin()" :checked="true" @ionChange="toggleFacilitySelection(facility)">
               <ion-label>
-                {{ facility.facilityName }}
+                {{ facility.facilityName || facility.facilityId }}
                 <p>{{ facility.facilityId }}</p>
               </ion-label>
             </ion-checkbox>
             <ion-label v-else>
-              {{ facility.facilityName }}
+              {{ facility.facilityName || facility.facilityId }}
               <p>{{ facility.facilityId }}</p>
             </ion-label>
           </ion-item>

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -23,7 +23,7 @@
               <ion-icon :icon="idCardOutline" slot="start" />
               <ion-select :label="translate('Clearance')" interface="popover" v-model="query.securityGroup" @ionChange="updateQuery()">
                 <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option :value="securityGroup.groupId" :key="index" v-for="(securityGroup, index) in securityGroups">{{ securityGroup.groupName }}</ion-select-option>
+                <ion-select-option :value="securityGroup.groupId" :key="index" v-for="(securityGroup, index) in securityGroups">{{ securityGroup.groupName || securityGroup.groupId }}</ion-select-option>
               </ion-select>
             </ion-item>
             <ion-item lines="none">
@@ -65,7 +65,7 @@
             <ion-item lines="none">
               <div class="tablet">
                 <ion-chip outline v-if="currentUser.securityGroupId">
-                  <ion-label>{{ currentUser.securityGroupName }}</ion-label>
+                  <ion-label>{{ currentUser.securityGroupName || currentUser.securityGroupId }}</ion-label>
                 </ion-chip>
                 <ion-label v-else>
                   {{ '-' }}
@@ -95,7 +95,7 @@
 
               <div class="tablet">
                 <ion-chip outline v-if="user.securityGroupId">
-                  <ion-label>{{ user.securityGroupName }}</ion-label>
+                  <ion-label>{{ user.securityGroupName || user.securityGroupId }}</ion-label>
                 </ion-chip>
                 <ion-label v-else>
                   {{ '-' }}


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#199 
### Short Description and Why It's Useful
- When no username is available for a security group or product store, the respective field will display the associated ID.

### Screenshots of Visual Changes before/after (If There Are Any)
![Screenshot from 2024-04-10 18-25-56](https://github.com/hotwax/users/assets/89250683/d914b5e0-6c01-48b4-a829-74675eee4a20)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)