### PR TITLE
Fixed: new password field will not be autofilled(#198)

### DIFF
--- a/src/components/ResetPasswordModal.vue
+++ b/src/components/ResetPasswordModal.vue
@@ -28,7 +28,8 @@
           v-model="newPassword" 
           id="newPassword" 
           :type="showNewPassword ? 'text' : 'password'"
-          :error-text="translate('Password requirements not fulfilled.')"/>
+          :error-text="translate('Password requirements not fulfilled.')"
+          autocomplete="new-password"/>
         <!-- <ion-button fill="clear" @click="showNewPassword = !showNewPassword">
           <ion-icon :icon="showNewPassword ? eyeOutline : eyeOffOutline"/>
         </ion-button> -->


### PR DESCRIPTION
### Related Issues

#198
### Short Description and Why It's Useful
When an admin or super user resets a user's password, the field where the new password is entered will be empty to avoid showing any sensitive information like the old password.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)