### PR TITLE
Fixed: infinite scroll issue when used with searchbar(#84)

### DIFF
--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -115,10 +115,20 @@
         </ion-fab-button>
       </ion-fab>
 
+      <!--
+        When searching for a keyword, and if the user moves to the last item, then the didFire value inside infinite scroll becomes true and thus the infinite scroll does not trigger again on the same page(https://github.com/hotwax/users/issues/84).
+
+        In ionic v7.6.0, an issue related to infinite scroll has been fixed that when more items can be added to the DOM, but infinite scroll does not fire as the window is not completely filled with the content(https://github.com/ionic-team/ionic-framework/issues/18071).
+        The above fix in ionic 7.6.0 is resulting in the issue of infinite scroll not being called again.
+
+        To fix this, we have added a key with value as queryString(searched keyword), so that the infinite scroll component can be re-rendered
+        whenever the searched string is changed resulting in the correct behaviour for infinite scroll
+      -->
       <ion-infinite-scroll
         @ionInfinite="loadMoreUsers($event)"
         threshold="100px"
         :disabled="!isScrollable"
+        :key="query.queryString"
       >
         <ion-infinite-scroll-content
           loading-spinner="crescent"


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #84 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
In ionic 7.6.0, an issue is fixed for triggering infinite scroll on quickly scrolling or items have not filled the complete page. This resulted in the issue of infinite scroll when used with search. So added a key on infinite scroll to re-render the same when keyword is changed

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)