### PR TITLE
Fixed: empty state will not show on Api fail(#211)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -349,14 +349,16 @@ const actions: ActionTree<UserState, RootState> = {
       "viewSize": payload.viewSize
     }
 
-    let users = [], total = 0;
-
+    let users = JSON.parse(JSON.stringify(state.users.list)), total = 0;
+    
     try {
       const resp = await UserService.fetchUsers(params)
 
       if(!hasError(resp) && resp.data.count) {
-        users = resp.data.docs
-        if(payload.viewIndex && payload.viewIndex > 0) users = JSON.parse(JSON.stringify(state.users.list)).concat(resp.data.docs)
+        if(payload.viewIndex && payload.viewIndex > 0) users = users.concat(resp.data.docs)
+          else{
+            users = resp.data.docs
+          }
         total = resp.data.count
       } else {
         throw resp.data

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -350,21 +350,22 @@ const actions: ActionTree<UserState, RootState> = {
     }
 
     let users = JSON.parse(JSON.stringify(state.users.list)), total = 0;
-    
-    try {
-      const resp = await UserService.fetchUsers(params)
 
-      if(!hasError(resp) && resp.data.count) {
-        if(payload.viewIndex && payload.viewIndex > 0) users = users.concat(resp.data.docs)
-          else{
-            users = resp.data.docs
-          }
-        total = resp.data.count
+    try {
+      const resp = await UserService.fetchUsers(params);
+
+      if (!hasError(resp) && resp.data.count) {
+        if (payload.viewIndex && payload.viewIndex > 0) {
+          users = users.concat(resp.data.docs);
+        } else {
+          users = resp.data.docs;
+        }
+        total = resp.data.count;
       } else {
-        throw resp.data
+        throw resp.data;
       }
     } catch(error) {
-      logger.error(error)
+      logger.error(error);
     }
 
     emitter.emit("dismissLoader");


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#211 
### Short Description and Why It's Useful
when api fails while loading more users, the previous loaded content will not be removed and empty state will also not get displayed.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)