### PR TITLE
FIxed: new user info will show after loader(#214)

### DIFF
--- a/src/views/UserConfirmation.vue
+++ b/src/views/UserConfirmation.vue
@@ -69,6 +69,7 @@
     mailOutline
   } from 'ionicons/icons';
   import { translate } from "@hotwax/dxp-components";
+  import emitter from "@/event-bus";
   
   export default defineComponent({
     name: "UserConfirmation",
@@ -95,7 +96,10 @@
     },
     props: ['partyId'],
     async ionViewWillEnter() {
+      this.selectedUser = '';
+      emitter.emit('presentLoader')
       await this.store.dispatch("user/getSelectedUserDetails", { partyId: this.partyId });
+      emitter.emit('dismissLoader')
     },
     methods: {
       async quickSetup() {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#214 
### Short Description and Why It's Useful
Added a loader before displaying the information of the newly made user and also emptying the state of the selectedUser, so won't show the information of the previous user. So after the loader, the user-confirmation page will show the new user credentials.



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)