### PR TITLE
Improved: added toast after successfully creating a new user(#215)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -207,6 +207,7 @@
   "Update user facilities": "Update user facilities",
   "Update Security Group": "Update Security Group",
   "Upload": "Upload",
+  "User created successfully": "User created successfully",
   "User details": "User details",
   "User disabled": "User disabled",
   "User login status updated successfully.": "User login status updated successfully.",

--- a/src/views/CreateUser.vue
+++ b/src/views/CreateUser.vue
@@ -206,6 +206,7 @@ export default defineComponent({
           if (partyTypeId === "PARTY_GROUP" ) {
             await UserService.addPartyToFacility({"partyId": partyId, "facilityId": payload.facilityId, "roleTypeId": "WAREHOUSE_MANAGER"});
           }
+          showToast(translate("User created successfully"));
           this.$router.replace({ path: `/user-confirmation/${partyId}` })
         } else {
           throw resp.data;

--- a/src/views/UserConfirmation.vue
+++ b/src/views/UserConfirmation.vue
@@ -69,6 +69,7 @@
     mailOutline
   } from 'ionicons/icons';
   import { translate } from "@hotwax/dxp-components";
+  import { showToast } from "@/utils";
   
   export default defineComponent({
     name: "UserConfirmation",
@@ -96,6 +97,7 @@
     props: ['partyId'],
     async ionViewWillEnter() {
       await this.store.dispatch("user/getSelectedUserDetails", { partyId: this.partyId });
+      showToast(translate("User created successfully"))
     },
     methods: {
       async quickSetup() {

--- a/src/views/UserConfirmation.vue
+++ b/src/views/UserConfirmation.vue
@@ -69,7 +69,6 @@
     mailOutline
   } from 'ionicons/icons';
   import { translate } from "@hotwax/dxp-components";
-  import { showToast } from "@/utils";
   
   export default defineComponent({
     name: "UserConfirmation",

--- a/src/views/UserConfirmation.vue
+++ b/src/views/UserConfirmation.vue
@@ -97,7 +97,6 @@
     props: ['partyId'],
     async ionViewWillEnter() {
       await this.store.dispatch("user/getSelectedUserDetails", { partyId: this.partyId });
-      showToast(translate("User created successfully"))
     },
     methods: {
       async quickSetup() {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#215 
### Short Description and Why It's Useful
After successfully creating a new user, a toast message will be displayed on the user interface to inform the user about the success of the operation.

### Screenshots of Visual Changes before/after (If There Are Any)
![Screenshot from 2024-04-18 18-48-43](https://github.com/hotwax/users/assets/89250683/aa76f724-20ca-4913-868e-5deceeea7121)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)