### PR TITLE
Improved: the helper-text on User Details Page(#231)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -227,7 +227,7 @@
   "User not found": "User not found",
   "Verify password": "Verify password",
   "View product store": "View product store",
-  "will be asked to reset their password when they login": "{name} will be asked to reset their password when they login",
+  "will be asked to reset their password when they login to OMS.": "{name} will be asked to reset their password when they login to OMS.",
   "Yes": "Yes",
   "You don't have permission to update the security group.": "You don't have permission to update the security group.",
   "Your user": "Your user"

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -139,7 +139,7 @@
                     <div slot="label">{{ translate("Username") }} <ion-text color="danger">*</ion-text></div>
                   </ion-input>
                 </ion-item>
-                <ion-item ref="password">
+                <ion-item ref="password" lines="none">
                   <ion-input 
                     label-placement="fixed" 
                     :placeholder="translate('Default password')" 
@@ -149,7 +149,7 @@
                     :type="showPassword ? 'text' : 'password'" 
                     @ionInput="validatePassword" 
                     @ionBlur="markPasswordTouched"
-                    :helper-text="translate('will be asked to reset their password when they login', { name: selectedUser.firstName ? selectedUser.firstName : selectedUser.groupName })"
+                    :helper-text="translate('will be asked to reset their password when they login to OMS.', { name: selectedUser.firstName ? selectedUser.firstName : selectedUser.groupName })"
                     :error-text="translate('Password should be at least 5 characters long and contain at least one number, alphabet and special character.')"
                   >
                     <div slot="label">{{ translate("Password") }} <ion-text color="danger">*</ion-text></div>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#231 
### Short Description and Why It's Useful
- Chnaged the incorrect Helper Text on User Details Page After Creating a New User.
- removed the extra line on the in the login details section around helper-text.


### Screenshots of Visual Changes before/after (If There Are Any)
[
![Screenshot from 2024-04-24 18-23-22](https://github.com/hotwax/users/assets/89250683/7c8a3da9-235b-4c9d-aeaf-5eb08170a854)
](url)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)