### PR TITLE
Fixed: Permissions tab URL will redirect to valid route(#233)

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -130,7 +130,7 @@ router.beforeEach((to, from) => {
   if (to.meta.permissionId && !hasPermission(to.meta.permissionId)) {
     let redirectToPath = from.path;
     // If the user has navigated from Login page or if it is page load, redirect user to settings page without showing any toast
-    if (redirectToPath == "/login" || redirectToPath == "/") redirectToPath = "/settings";
+    if (redirectToPath == "/login" || redirectToPath == "/") redirectToPath = "/tabs/settings";
     else {
       showToast(translate('You do not have permission to access this page'));
     }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#233 
### Short Description and Why It's Useful
- Fixed the redirection of Permissions URL to blank page or settings page.
- To fix the incorrect redirection issue, I can update the `redirectToPath` in my `beforeEach` guard to use `/tabs/settings` instead of `/settings`.
- when the user navigates from `/tabs/permissions` to `/settings`, they will be redirected to `/tabs/settings` instead


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)