### PR TITLE
Improved: the logic of router.beforeEach and  fix the toast issue while navigating(#233)

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -127,16 +127,13 @@ const router = createRouter({
 })
 
 router.beforeEach((to, from) => {
-  if (to.meta.permissionId && !hasPermission(to.meta.permissionId)) {
-    let redirectToPath = from.path;
-    // If the user has navigated from Login page or if it is page load, redirect user to settings page without showing any toast
-    if (redirectToPath == "/login" || redirectToPath == "/") redirectToPath = "/tabs/settings";
-    else {
-      showToast(translate('You do not have permission to access this page'));
+  const permissionId = to.meta.permissionId;
+  if (permissionId && !hasPermission(permissionId)) {
+    showToast(translate('You do not have permission to access this page'));
+    if (from.path === '/login' || from.path === '/') {
+      return { path: '/tabs/settings' };
     }
-    return {
-      path: redirectToPath,
-    }
+    return { path: from.path };
   }
 })
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#233 
### Short Description and Why It's Useful
- Improved the logic of `router.beforeEach`.
- The `router.beforeEach` function checks if the user has permission to access a route. If not, it shows a toast message and redirects the user based on the previous route. If the previous route was the login page or the root path, the user is redirected to the settings page; otherwise, they are redirected back to the previous route



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)