### PR TITLE
Fixed: redundant api calls are made when fetching current user information on infinite scroll

### DIFF
--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -270,8 +270,12 @@ export default defineComponent({
       this.fetchUsers();
     },
     async fetchUsers(vSize?: any, vIndex?: any) {
-      if(!this.query.queryString) await this.fetchLoggedInUserDetails()
-      else this.currentUser = {}
+      if(!this.query.queryString) {
+        // Do not fetch the current user information again when vIndex is passed(as we only pass vIndex in case of infinite scroll call), as we already have information for current user
+        !vIndex && await this.fetchLoggedInUserDetails()
+      } else {
+        this.currentUser = {}
+      }
 
       const viewSize = vSize ? vSize : process.env.VUE_APP_VIEW_SIZE;
       const viewIndex = vIndex ? vIndex : 0;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->


### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
As we fetch the current user information on initial load of the page, but on infinite scroll the same information is fetched again, thus making redundant call. Added a check to not fetch current user information when scrolling on the page.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)