### PR TITLE
Fixed: payload is fetched when user toggles from true to false

### DIFF
--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -319,7 +319,7 @@
             <ion-list>
               <ion-item :disabled="!hasPermission(Actions.APP_UPDT_PICKER_CONFG)">
                 <ion-toggle @click.prevent="updatePickerRoleStatus($event)" :checked="selectedUser.isWarehousePicker === true">
-                  {{ translate("Show as picker") }}
+                  {{ translate("Show as picker") }} 
                 </ion-toggle>
               </ion-item>
               <ion-item lines="none" button detail :disabled="!hasPermission(Actions.APP_UPDT_FULFILLMENT_FACILITY) || selectedUser.securityGroup.groupId === 'INTEGRATION'" @click="selectFacility()">
@@ -998,8 +998,22 @@ export default defineComponent({
             "roleTypeIdTo": "WAREHOUSE_PICKER"
           })
         } else {
+          const response = await UserService.fetchPartyRelationship({
+            inputFields: {
+            partyIdTo: this.selectedUser.partyId,
+            roleTypeIdTo: 'WAREHOUSE_PICKER',
+            roleTypeIdTo_op: 'equals'
+          },
+          filterByDate: 'Y',
+          viewSize: 1,
+          entityName: 'PartyRelationship',
+          fieldList: ['partyIdTo', 'roleTypeIdTo', "partyIdFrom", "roleTypeIdFrom", "fromDate"]
+        })
+        const fetchedRelationShip = response.data.docs[0]
+        console.log(fetchedRelationShip)
+        
           resp = await UserService.updatePartyRelationship({
-            ...this.selectedUser?.pickerRelationship,
+            ...fetchedRelationShip,
             "thruDate": DateTime.now().toMillis()
           })
         }
@@ -1012,6 +1026,7 @@ export default defineComponent({
         }
       } catch (error) {
         showToast(translate('Failed to update user role.'))
+        console.log(error)
         logger.error(error)
       }
     },
@@ -1074,7 +1089,7 @@ export default defineComponent({
       alert.present()
     },
     async updateUserStatus(event: any) {
-      event.stopImmediatePropagation();
+      
 
       const isChecked = !event.target.checked
       let resp;

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -998,25 +998,24 @@ export default defineComponent({
             "roleTypeIdTo": "WAREHOUSE_PICKER"
           })
         } else {
-          const response = await UserService.fetchPartyRelationship({
-            inputFields: {
-            partyIdTo: this.selectedUser.partyId,
-            roleTypeIdTo: 'WAREHOUSE_PICKER',
-            roleTypeIdTo_op: 'equals'
-          },
-          filterByDate: 'Y',
-          viewSize: 1,
-          entityName: 'PartyRelationship',
-          fieldList: ['partyIdTo', 'roleTypeIdTo', "partyIdFrom", "roleTypeIdFrom", "fromDate"]
-        })
-        const fetchedRelationShip = response.data.docs[0]
-        console.log(fetchedRelationShip)
+            const response = await UserService.fetchPartyRelationship({
+              inputFields: {
+                partyIdTo: this.selectedUser.partyId,
+                roleTypeIdTo: 'WAREHOUSE_PICKER',
+                roleTypeIdTo_op: 'equals'
+              },
+              filterByDate: 'Y',
+              viewSize: 1,
+              entityName: 'PartyRelationship',
+              fieldList: ['partyIdTo', 'roleTypeIdTo', "partyIdFrom", "roleTypeIdFrom", "fromDate"]
+            })
+            const fetchedRelationShip = response.data.docs[0]
         
-          resp = await UserService.updatePartyRelationship({
-            ...fetchedRelationShip,
-            "thruDate": DateTime.now().toMillis()
-          })
-        }
+            resp = await UserService.updatePartyRelationship({
+              ...fetchedRelationShip,
+              "thruDate": DateTime.now().toMillis()
+            })
+          }
         if (!hasError(resp)) {
           showToast(translate('User picker role updated successfully.'))
           // updating toggle state on success

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -1026,7 +1026,6 @@ export default defineComponent({
         }
       } catch (error) {
         showToast(translate('Failed to update user role.'))
-        console.log(error)
         logger.error(error)
       }
     },
@@ -1089,7 +1088,7 @@ export default defineComponent({
       alert.present()
     },
     async updateUserStatus(event: any) {
-      
+      event.stopImmediatePropagation();
 
       const isChecked = !event.target.checked
       let resp;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#253 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
selected user was not fetching data at first because of which payload was going empty resulting in bug , now we are fetching selectedUser information and than calling updatePartyRelationship service call with updated payload 

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)