### PR TITLE
Improved: UI for the select facilities option in the quick user setup page (#252)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -120,6 +120,7 @@
   "Login": "Login",
   "Login details": "Login details",
   "Logout": "Logout",
+  "Manage": "Manage",
   "Name": "Name",
   "Name is required.": "Name is required.",
   "New password": "New password",

--- a/src/views/UserQuickSetup.vue
+++ b/src/views/UserQuickSetup.vue
@@ -66,17 +66,20 @@
           <ion-list-header>
             <ion-label>{{ translate('Select Facilities') }}</ion-label>
             <ion-button fill="clear" @click="addFacilities()">
-              {{ translate("Add") }}
-              <ion-icon slot="end" :icon="addCircleOutline"></ion-icon>
+              {{ translate(selectedFacilities.length ? "Manage" : "Add") }}
+              <ion-icon slot="end" :icon="selectedFacilities.length ? settingsOutline : addCircleOutline"></ion-icon>
             </ion-button>
           </ion-list-header>
-          <ion-item v-for="facility in facilities" :key="facility.facilityId">
-            <ion-checkbox v-if="!isFacilityLogin()" :checked="true" @ionChange="toggleFacilitySelection(facility)">
+          <ion-item v-for="facility in selectedFacilities" :key="facility.facilityId">
+            <template v-if="!isFacilityLogin()">
               <ion-label>
                 {{ facility.facilityName || facility.facilityId }}
                 <p>{{ facility.facilityId }}</p>
               </ion-label>
-            </ion-checkbox>
+              <ion-button slot="end" fill="clear" color="danger"  @click="toggleFacilitySelection(facility)">
+                <ion-icon :icon="closeOutline" slot="icon-only" />
+              </ion-button>
+            </template>
             <ion-label v-else>
               {{ facility.facilityName || facility.facilityId }}
               <p>{{ facility.facilityId }}</p>
@@ -105,7 +108,6 @@
 import {
   IonBackButton,
   IonButton,
-  IonCheckbox,
   IonContent,
   IonHeader,
   IonIcon,
@@ -131,9 +133,11 @@ import {
   addCircleOutline,
   arrowForwardOutline,
   caretDownOutline,
+  closeOutline,
   documentTextOutline,
   eyeOffOutline,
-  eyeOutline
+  eyeOutline,
+  settingsOutline
 } from 'ionicons/icons';
 import { copyToClipboard, showToast, isValidPassword, isValidEmail } from '@/utils'
 import { translate } from "@hotwax/dxp-components";
@@ -147,7 +151,6 @@ export default defineComponent({
   components: {
     IonBackButton,
     IonButton,
-    IonCheckbox,
     IonContent,
     IonHeader,
     IonIcon,
@@ -176,7 +179,6 @@ export default defineComponent({
     return {
       userTemplateId: "FULFILLMENT",
       selectedUserTemplate: {} as any,
-      facilities: [] as any,
       selectedFacilities: [] as any,
       selectedProductStores: [] as any,
       showPassword: false,
@@ -279,7 +281,6 @@ export default defineComponent({
     if (this.isFacilityLogin()) {
       const addedFacilityIds = this.selectedUser.facilities.map((facility: any) => facility.facilityId);
       const addedFacilities = this.allFacilities.filter((facility: any) =>  addedFacilityIds.includes(facility.facilityId));
-      this.facilities = addedFacilities;
       this.selectedFacilities = addedFacilities;
     }
     await this.initializeFormData();
@@ -467,7 +468,6 @@ export default defineComponent({
 
       selectFacilityModal.onDidDismiss().then((result) => {
         if (result.data && result.data.value) {
-          this.facilities = result.data.value.selectedFacilities;
           this.selectedFacilities = result.data.value.selectedFacilities;
         }
       })
@@ -505,9 +505,11 @@ export default defineComponent({
       addCircleOutline,
       arrowForwardOutline,
       caretDownOutline,
+      closeOutline,
       documentTextOutline,
       eyeOffOutline,
       eyeOutline,
+      settingsOutline,
       translate
     };
   }

--- a/src/views/UserQuickSetup.vue
+++ b/src/views/UserQuickSetup.vue
@@ -76,7 +76,7 @@
                 {{ facility.facilityName || facility.facilityId }}
                 <p>{{ facility.facilityId }}</p>
               </ion-label>
-              <ion-button slot="end" fill="clear" color="danger"  @click="toggleFacilitySelection(facility)">
+              <ion-button slot="end" fill="clear" color="danger" @click="toggleFacilitySelection(facility)">
                 <ion-icon :icon="closeOutline" slot="icon-only" />
               </ion-button>
             </template>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#252

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Changed the label for button to open select facilities modal.
- Improved selected facilities visibility and management on quick user setup.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before
![Screenshot from 2024-08-13 14-38-20](https://github.com/user-attachments/assets/7a1d0910-c15e-43e5-a376-d560eb16e692)

After
![Screenshot from 2024-08-13 14-38-47](https://github.com/user-attachments/assets/0461f883-f94a-4653-9824-c899b21ee122)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)