### PR TITLE
Improved: Updated the toast message while navigating to permissions page(#233)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -230,5 +230,6 @@
   "will be asked to reset their password when they login": "{name} will be asked to reset their password when they login",
   "Yes": "Yes",
   "You don't have permission to update the security group.": "You don't have permission to update the security group.",
+  "The requested page was not available to your user. Please contact your administrator to update your permissions.": "The requested page was not available to your user. Please contact your administrator to update your permissions.",
   "Your user": "Your user"
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -129,7 +129,7 @@ const router = createRouter({
 router.beforeEach((to, from) => {
   const permissionId = to.meta.permissionId;
   if (permissionId && !hasPermission(permissionId)) {
-    showToast(translate('You do not have permission to access this page'));
+    showToast(translate('The requested page was not available to your user. Please contact your administrator to update your permissions.'));
     if (from.path === '/login' || from.path === '/') {
       return { path: '/tabs/settings' };
     }


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#233 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- In case when the user doesn't have permission for the permissions page, updated the toast message to show:
  `The requested page was not available to your user. Please contact your administrator to update your permissions.`

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)