### PR TITLE
Fixed:  linked user count matches the Users page after clicking the link(#266)

### DIFF
--- a/src/views/Permissions.vue
+++ b/src/views/Permissions.vue
@@ -154,13 +154,18 @@ export default defineComponent({
 
       try {
         const resp = await PermissionService.getSecurityGroupUsers({
-          entityName: "UserLoginAndSecurityGroup",
-          distinct: "Y",
+          entityName: "PartyAndUserLoginSecurityGroupDetails",
           noConditionFind: "Y",
+          fromDateName: "relationshipFromDate",
+          thruDateName: "relationshipThruDate",
           filterByDate: "Y",
-          viewSize: 100,
+          distinct: "Y",
+          viewSize: 1,
+          viewIndex: 0,
+          fieldList: ['partyId','securityGroupName'],
           inputFields: {
-            groupId: this.currentGroup.groupId
+            securityGroupId: this.currentGroup.groupId,
+            roleTypeIdTo: "APPLICATION_USER"
           }
         })
 


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#266 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, the `UserLoginAndSecurityGroup` entity was showing users who were not `APPLICATION_USER`.
- I changed it to `PartyAndUserLoginSecurityGroupDetails` and added a filter for `roleTypeId: APPLICATION_USER`, which now only retrieves users with the `APPLICATION_USER` role.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)