### PR TITLE
Fixed: Linked users count should always display when the security group is accessed(#263)

### DIFF
--- a/src/views/Permissions.vue
+++ b/src/views/Permissions.vue
@@ -125,7 +125,10 @@ export default defineComponent({
     await this.store.dispatch('util/getClassificationSecurityGroups')
     if(!this.allPermissions.length) await this.store.dispatch('permission/getAllPermissions')
     if(!Object.keys(this.permissionsByClassificationGroups).length) await this.store.dispatch('permission/getPermissionsByClassificationGroups')
-    if(this.currentGroup.groupId) await this.store.dispatch('permission/getPermissionsByGroup', this.currentGroup.groupId)
+    if(this.currentGroup.groupId) {
+      await this.store.dispatch('permission/getPermissionsByGroup', this.currentGroup.groupId)
+      await this.getUsersCount()
+    }
   },
   methods: {
     createGroup() {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#263 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- The linked users count (e.g., "6 users") should always be an active link when the security group is accessed, no matter the previous navigation.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)