### PR TITLE
Fixed: added permissions description column instead of the security group description(#265)

### DIFF
--- a/src/views/Permissions.vue
+++ b/src/views/Permissions.vue
@@ -204,8 +204,8 @@ export default defineComponent({
           permissionsJson.push({
             "Group ID": permission.groupId,
             "Permission ID": permission.permissionId,
-            "Permission Desc": permission.description,
-            "Member Created Date": DateTime.fromMillis(permission.fromDate).toFormat('dd-MM-yyyy')
+            "Permission Desc": permission.permissionDescription,
+            "Association date": DateTime.fromMillis(permission.fromDate).toFormat('dd-MM-yyyy')
           })
         })
       } else {
@@ -240,8 +240,8 @@ export default defineComponent({
                 permissionsByGroup.push({
                   "Group Id": permission.groupId,
                   "Permission ID": permission.permissionId,
-                  "Permission Desc": permission.description,
-                  "Member Created Date": DateTime.fromMillis(permission.fromDate).toFormat('dd-MM-yyyy')
+                  "Permission Desc": permission.permissionDescription,
+                  "Association date": DateTime.fromMillis(permission.fromDate).toFormat('dd-MM-yyyy')
                 });
               });
               viewIndex++;


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#265 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- The download will now show the permissions description in the column instead of the security group description.
- Additionally, the column name has been changed to `Association date` instead of `Created date`.
### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)