### PR TITLE
Fixed: Fulfillment section updated after removing securityGroup from the ellipse button (#278)

### DIFF
--- a/src/components/SecurityGroupActionsPopover.vue
+++ b/src/components/SecurityGroupActionsPopover.vue
@@ -51,8 +51,8 @@
       })
     },
     methods: {
-      closePopover() {
-        popoverController.dismiss();
+      closePopover(userSecurityGroups: any) {
+        popoverController.dismiss(userSecurityGroups);
       },
       getDateTime(time: any) {
         return DateTime.fromMillis(time).toLocaleString(DateTime.DATETIME_MED);
@@ -73,7 +73,7 @@
         // refetching security groups
         const userSecurityGroups = await UserService.getUserSecurityGroups(this.selectedUser.userLoginId)
         this.store.dispatch('user/updateSelectedUser', { ...this.selectedUser, securityGroups: userSecurityGroups })
-        this.closePopover()
+        this.closePopover(userSecurityGroups)
       },
       async confirmRemove() {
         const message = 'Are you sure you want to perform this action?'

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -850,7 +850,10 @@ export default defineComponent({
         event,
         showBackdrop: false,
       });
-      return securityGroupActionsPopover.present();
+      securityGroupActionsPopover.present();
+
+      const result = await securityGroupActionsPopover.onDidDismiss();
+      this.isUserFulfillmentAdmin = result.data.length ? await UserService.isUserFulfillmentAdmin(result.data.map((group: any) => group.groupId)) : false
     },
     async openProductStoreActionsPopover(event: Event, store: any) {
       const productStoreActionsPopover = await popoverController.create({


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#278 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Upon changing the security group, permissions to access the Fulfillment section are re-fetched.
- The Fulfillment section is updated after the security group is removed via the popover's remove button, accessed from the ellipse icon.


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)