### PR TITLE
Improved: Adding secuity group is disabled for newly created user without useLoginID(#279)

### DIFF
--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -267,8 +267,7 @@
                   <ion-icon slot="end" :icon="pencilOutline" />
                 </ion-button>
               </ion-list-header>
-
-              <ion-button :disabled="!hasPermission(Actions.APP_SECURITY_GROUP_CREATE)" v-if="!userSecurityGroups.length" @click="selectSecurityGroup()" fill="outline" expand="block" class="ion-margin">
+              <ion-button :disabled="!hasPermission(Actions.APP_SECURITY_GROUP_CREATE) || !selectedUser.userLoginId" v-if="!userSecurityGroups.length" @click="selectSecurityGroup()" fill="outline" expand="block" class="ion-margin">
                 <ion-icon :icon="addOutline" slot='start' />
                 {{ translate('Add to security group') }}
               </ion-button>


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#279 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Disabled the `Add Security Group` button for newly created users who do not have a `userLoginId`.
- Admins/Super users will not be able to assign a security group to newly created users, as the button appears disabled.


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)