### PR TITLE
Improved: validation over fetching securitygroup assoc history for user without userLogin (#297)

### DIFF
--- a/src/components/UserSecurityGroupAssocHistoryModal.vue
+++ b/src/components/UserSecurityGroupAssocHistoryModal.vue
@@ -89,6 +89,8 @@ export default defineComponent({
       modalController.dismiss({ dismissed: true});
     },
     async fetchUserSecurityGroupAssoHistory() {
+      if(!this.selectedUser.userLoginId) return;
+
       const securityGroupNameByGroupId = {} as any;
       let userGroupAssocHistories = [] as any;
       try {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#297

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Updated code to not fetch security group assoc history in case of user with no userLogin.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)