### PR TITLE
Fixed: issue of empty state not being displayed when searching for a permission whose type is HIDDEN(#277)

### DIFF
--- a/src/components/PermissionItems.vue
+++ b/src/components/PermissionItems.vue
@@ -21,14 +21,14 @@
 
   <template v-if="arePermissionsAvailable()">
     <div v-for="(group, groupId) in filteredPermissions" :key="groupId">
-      <ion-item-divider v-if="group.groupId !== 'SGC_HIDDEN' && group.permissions.length" class="ion-margin-vertical" color="light">
+      <ion-item-divider v-if="group.permissions.length" class="ion-margin-vertical" color="light">
         <ion-label>
           {{ group.groupName || group.groupId }}
         </ion-label>
         <ion-note slot="end">{{ group.permissions.length }}</ion-note>
       </ion-item-divider>
 
-      <section v-if="group.groupId !== 'SGC_HIDDEN'">
+      <section>
         <ion-card v-for="permission in group.permissions" :key="permission.permissionId" button @click="updatePermissionAssociation(permission)">
           <ion-card-header>
             <div>

--- a/src/store/modules/permission/getters.ts
+++ b/src/store/modules/permission/getters.ts
@@ -36,6 +36,9 @@ const getters: GetterTree<PermissionState, RootState> = {
       })
     }
 
+    // Remove the hidden permissions so to not display them on the UI
+    delete groupType["SGC_HIDDEN"];
+
     return groupType
   },
   getQuery(state) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#277 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Removed the check for HIDDEN group from the template part and removed the HIDDEN group records from the getter which was returning the permissions to be displayed on UI

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)