### PR TITLE
Implemented: Disable reset password, disable user toggle and add credential button for non super user.(#290)

### DIFF
--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -47,7 +47,7 @@
                 <input @change="uploadImage" class="ion-hide" type="file" accept="image/*" id="profilePic"/>
                 <label for="profilePic">{{ translate("Upload") }}</label>
               </ion-item>
-              <ion-item lines="none">
+              <ion-item lines="none" :disabled="!hasPermission(Actions.APP_UPDT_BLOCK_LOGIN)">
                 <ion-icon :icon="cloudyNightOutline" slot="start" />
                 <ion-toggle :checked="selectedUser.statusId === 'PARTY_DISABLED'" @click.prevent="updateUserStatus($event)">
                   {{ translate("Disable user") }}
@@ -159,7 +159,7 @@
                   </ion-input>
                 </ion-item>
               </ion-list>
-              <ion-button @click="createNewUserLogin()" fill="outline" expand="block">
+              <ion-button @click="createNewUserLogin()" :disabled="!hasPermission(Actions.APP_UPDT_BLOCK_LOGIN)" fill="outline" expand="block">
                 {{ translate('Add credentials') }}
               </ion-button>
             </template>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#290 
#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Now non super user cannnot reset password, add credentials or diable the user.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/fa22e243-e151-483b-8e1d-ee0acc4b35d9)
![image](https://github.com/user-attachments/assets/6471d9b2-95fb-456f-b0a4-9f65ff99b361)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)