### PR TITLE
Improved: Displayed current security group details in the Permission History modal (#295)

### DIFF
--- a/src/components/UserSecurityGroupAssocHistoryModal.vue
+++ b/src/components/UserSecurityGroupAssocHistoryModal.vue
@@ -17,7 +17,7 @@
           {{ assocHistory.groupName ? assocHistory.groupName : assocHistory.groupId }}
           <p>{{ assocHistory.groupId }}</p>
         </ion-label>
-        <ion-note slot="end">{{ getDateWithOrdinalSuffix(assocHistory.fromDate) }} - {{ getDateWithOrdinalSuffix(assocHistory.thruDate) }}</ion-note>
+        <ion-note slot="end">{{ getDateWithOrdinalSuffix(assocHistory.fromDate) }} - {{ assocHistory.thruDate ? getDateWithOrdinalSuffix(assocHistory.thruDate) : translate('Current') }}</ion-note>
       </ion-item>
     </ion-list>
     <div class="empty-state" v-else>
@@ -98,7 +98,6 @@ export default defineComponent({
           entityName: "UserLoginAndSecurityGroup",
           inputFields: {
             userLoginId: this.selectedUser.userLoginId,
-            thruDate_op: "not-empty"
           },
           orderBy: "thruDate DESC",
           viewSize: 250
@@ -109,6 +108,9 @@ export default defineComponent({
           userGroupAssocHistories.map((history: any) => {
             history["groupName"] = securityGroupNameByGroupId[history.groupId]
           })
+          const currentSecurityGroups = userGroupAssocHistories.filter((history: any) => !history.thruDate);
+          const expiredSecurityGroups = userGroupAssocHistories.filter((history: any) => history.thruDate);
+          userGroupAssocHistories = currentSecurityGroups.concat(expiredSecurityGroups);
         } else {
           throw resp.data;
         }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -44,6 +44,7 @@
   "Create a new user": "Create a new user",
   "created": "created",
   "Created by": "Created by {userLoginId}",
+  "Current": "Current",
   "Deactivate": "Deactivate",
   "Default password": "Default password",
   "Description": "Description",


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#295 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, only expired security groups that were associated with the user were displayed in the modal.  
- Now, we also show the currently active security groups at the top of the list, with a date range from the start date to the `current` text.
### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

![image](https://github.com/user-attachments/assets/059b4009-1b2e-4791-8ee1-bef00d4c830e)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)