### PR TITLE
Displaying info message when no user login available and hiding the history modal icon if user was present in at least one security group. (#319)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -177,7 +177,7 @@
   "Security Group": "Security Group", 
   "Security Groups": "Security Groups", 
   "Security group updated successfully.": "Security group updated successfully.", 
-  "Select security groups to grant access to different parts of the application.": "Select security groups to grant access to different parts of the application.",
+  "Security groups can only be assigned after a login is created. Please add login credentials for above.": "Security groups can only be assigned after a login is created. Please add login credentials for above.",
   "Replace profile picture": "Replace profile picture",
   "Reset password email": "Reset password email",
   "Save": "Save",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -177,6 +177,7 @@
   "Security Group": "Security Group", 
   "Security Groups": "Security Groups", 
   "Security group updated successfully.": "Security group updated successfully.", 
+  "Select security groups to grant access to different parts of the application.": "Select security groups to grant access to different parts of the application.",
   "Replace profile picture": "Replace profile picture",
   "Reset password email": "Reset password email",
   "Save": "Save",

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -1314,11 +1314,10 @@ export default defineComponent({
           throw resp.data;
         }
       } catch (error) {
-        console.error("Error fetching user security group association history:", error);
+        logger.error("Error fetching user security group association history:", error);
       }
 
-      this.userGroupAssocHistories = userGroupAssocHistories; // Store in local variable
-      console.log("Fetched userGroupAssocHistories:", userGroupAssocHistories);
+      this.userGroupAssocHistories = userGroupAssocHistories;
     }
   },
   setup() {

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -273,7 +273,7 @@
                 {{ translate('Add to security group') }}
               </ion-button>
               <ion-card-content v-if="!selectedUser.userLoginId">
-                {{ translate('Select security groups to grant access to different parts of the application.') }}
+                {{ translate('Security groups can only be assigned after a login is created. Please add login credentials for above.') }}
               </ion-card-content>
 
               <ion-item v-if="selectedUser.userLoginId && userGroupAssocHistories.length">

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -272,6 +272,9 @@
                 <ion-icon :icon="addOutline" slot='start' />
                 {{ translate('Add to security group') }}
               </ion-button>
+              <ion-card-content v-if="!selectedUser.userLoginId">
+                {{ translate('Select security groups to grant access to different parts of the application.') }}
+              </ion-card-content>
 
               <ion-item>
                 <ion-label>{{ translate("View history") }}</ion-label>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#319 

### Short Description and Why It's Useful
Solved these two tasks given in issue-

1. If no user login is available for someone then displaying message under the disabled button.
2. The changes ensure that the history is fetched when the page loads, stored in a local variable, and used for conditional rendering  the UserSecurityGroupAssocHistoryModal.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 26-03-25 08:08:34 PM IST.webm](https://github.com/user-attachments/assets/003bd309-52e7-468d-b402-49e12e686c9f)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)