### PR TITLE
Improved: user does not require userLogin id to disable user.(#318)

### DIFF
--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -1154,7 +1154,7 @@ export default defineComponent({
       emitter.emit('presentLoader')
 
       try {
-        if (isChecked) {   
+        if (isChecked && this.selectedUser.userLoginId) {   
           await UserService.updateUserLoginStatus({
             enabled: 'N',
             partyId: this.partyId,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#318 
#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Now user does not require userLogin Id to disable a particular user.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)