### PR TITLE
Fixed: "Require password reset on login" toggle change (#326)

### DIFF
--- a/src/views/UserQuickSetup.vue
+++ b/src/views/UserQuickSetup.vue
@@ -44,7 +44,7 @@
             </ion-input>
           </ion-item>
           <ion-item ion-margin-top>
-            <ion-toggle :disabled="selectedUserTemplate.isPasswordChangeDisabled" :checked="formData.requirePasswordChange" label-placement="start" justify="space-between">
+            <ion-toggle :disabled="selectedUserTemplate.isPasswordChangeDisabled" :checked="formData.requirePasswordChange" label-placement="start" justify="space-between" @ionChange="toggleRequirePasswordChange">
               {{ translate("Require password reset on login") }}
             </ion-toggle>
           </ion-item>
@@ -493,6 +493,9 @@ export default defineComponent({
         }
       })
       return selectProductStoreModal.present();
+    },
+    toggleRequirePasswordChange() {
+      this.formData.requirePasswordChange = !this.formData.requirePasswordChange;
     }
   },
   setup() {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#326 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- After toggling the "Require password reset on login" option, the requirePasswordChange value is passed as true.
### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)