### PR TITLE
Fixed: Correct toast message is now shown when a user already exists during quick setup (#336)

### DIFF
--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -523,7 +523,9 @@ const finishSetup = async (payload: any): Promise <any> => {
     if (selectedTemplate.isUserLoginRequired || selectedUser.partyTypeId === "PARTY_GROUP") {
 
       if(await isUserLoginIdAlreadyExists(payload.formData.userLoginId)) {
-        throw `Could not create login user: user with ID ${payload.formData.userLoginId} already exists.`
+        throw {
+          errorMessage: translate('Could not create login user: user with ID already exists.', { userLoginId: payload.formData.userLoginId }),
+        }
       }
 
       const resp = await createNewUserLogin({

--- a/src/views/UserQuickSetup.vue
+++ b/src/views/UserQuickSetup.vue
@@ -377,9 +377,9 @@ export default defineComponent({
         } else {
           this.$router.replace({ path: `/user-details/${this.partyId}` });
         }
-      } catch (err) {
+      } catch (err: any) {
         logger.error('error', err)
-        showToast(err ? translate(err) : translate('Failed to quick setup user.'));
+        showToast(err.errorMessage ? err.errorMessage : translate('Failed to quick setup user.'));
       }
     },
     async finishSetupAlert(userLoginId:  any) {

--- a/src/views/UserQuickSetup.vue
+++ b/src/views/UserQuickSetup.vue
@@ -379,7 +379,7 @@ export default defineComponent({
         }
       } catch (err) {
         logger.error('error', err)
-        showToast(translate('Failed to quick setup user.'))
+        showToast(err ? translate(err) : translate('Failed to quick setup user.'));
       }
     },
     async finishSetupAlert(userLoginId:  any) {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#336 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Now, when we create a new user and the user already exists, the correct toast message will be shown during quick setup.
### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/fc4c7169-0c96-4c4e-ae93-e954a1cd921f)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)