### PR TITLE
Fixed: Role type for newly created user is changed to WAREHOUSE_PICKER from WAREHOUSE_MANAGER, (#347)

### DIFF
--- a/src/views/CreateUser.vue
+++ b/src/views/CreateUser.vue
@@ -205,7 +205,7 @@ export default defineComponent({
         if (resp.status === 200 && !hasError(resp) && resp.data.partyId) {
           const partyId = resp.data.partyId;
           if (partyTypeId === "PARTY_GROUP" ) {
-            await UserService.addPartyToFacility({"partyId": partyId, "facilityId": payload.facilityId, "roleTypeId": "WAREHOUSE_MANAGER"});
+            await UserService.addPartyToFacility({"partyId": partyId, "facilityId": payload.facilityId, "roleTypeId": "WAREHOUSE_PICKER"});
           }
           showToast(translate("User created successfully"));
           this.$router.replace({ path: `/user-confirmation/${partyId}` })

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -918,7 +918,7 @@ export default defineComponent({
             try {
               const resp = await UserService.ensurePartyRole({
                 partyId: this.partyId,
-                roleTypeId: 'WAREHOUSE_MANAGER',
+                roleTypeId: 'WAREHOUSE_PICKER',
               })
               if (hasError(resp)) {
                 showToast(translate('Something went wrong.'));
@@ -934,7 +934,7 @@ export default defineComponent({
             .map(async (payload: any) => await UserService.addPartyToFacility({
               partyId: this.selectedUser.partyId,
               facilityId: payload.facilityId,
-              roleTypeId: 'WAREHOUSE_MANAGER',
+              roleTypeId: 'WAREHOUSE_PICKER',
             }))
           )
 
@@ -1265,10 +1265,10 @@ export default defineComponent({
 
       return securityGroups.filter((group: any) => !excludedSecurityGroups.includes(group.groupId))
     },
-    // Currently a user is getting associated with two roles at a time i.e., 'WAREHOUSE_MANAGER' and 'FAC_LOGIN'
-    // And here we only want to show records of 'WAREHOUSE_MANAGER'
+    // Currently a user is getting associated with two roles at a time i.e., 'WAREHOUSE_PICKER' and 'FAC_LOGIN'
+    // And here we only want to show records of 'WAREHOUSE_PICKER'
     getUserFacilities() {
-      return this.selectedUser.facilities.filter((facility: any) => facility.roleTypeId === 'WAREHOUSE_MANAGER')
+      return this.selectedUser.facilities.filter((facility: any) => facility.roleTypeId === 'WAREHOUSE_PICKER')
     },
     async openUserSecurityGroupAssocHistoryModal() {
       const userSecurityGroupAssocHistoryModal = await modalController.create({

--- a/src/views/UserQuickSetup.vue
+++ b/src/views/UserQuickSetup.vue
@@ -229,7 +229,7 @@ export default defineComponent({
           "isUserLoginRequired": true,
           "isEmployeeIdRequired": true,
           "isFacilityRequired": true,
-          "facilityRoleTypeId": "WAREHOUSE_MANAGER",
+          "facilityRoleTypeId": "WAREHOUSE_PICKER",
           "isProductStoreRequired": false,
           "productStoreRoleTypeId": ""
         },


### PR DESCRIPTION
Role type for newly created user is changed to WAREHOUSE_PICKER from WAREHOUSE_PICKER

### Related Issues

#347

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When facilities are added to users, the secas working for employee indexing were set to take WAREHOUSE_PICKER as user's roleTypeId, due to which indexing wasn't being performed




### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)