### PR TITLE
Fixed : Option To Add Facility Association When Showing User #340

### DIFF
--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -374,10 +374,10 @@
                   {{ translate("Show as picker") }}
                 </ion-toggle>
               </ion-item>
-              <ion-item lines="none" v-if="isUserFulfillmentAdmin">
+              <ion-item v-if="isUserFulfillmentAdmin">
                 <ion-label>{{ translate("This user has 'STOREFULFILLMENT_ADMIN' permission, enabling access to all facilities.") }}</ion-label>
               </ion-item>
-              <ion-item lines="none" button detail v-else @click="selectFacility()" :disabled="!hasPermission(Actions.APP_UPDT_FULFILLMENT_FACILITY) || checkUserAssociatedSecurityGroup('INTEGRATION')">
+              <ion-item lines="none" button detail @click="selectFacility()" :disabled="!hasPermission(Actions.APP_UPDT_FULFILLMENT_FACILITY) || checkUserAssociatedSecurityGroup('INTEGRATION')">
                 <ion-label>{{ getUserFacilities().length === 1 ? translate('Added to 1 facility') : translate('Added to facilities', { count: getUserFacilities().length }) }}</ion-label>
               </ion-item>
             </ion-list>


### PR DESCRIPTION
Option To Add Facility Association When Showing User

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#340 : Option To Add Facility Association When Showing User As Picker

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- When creating a user as picker, option to associate with facility should also be provided, so as to avoid confusion in case user has STOREFULFILLMENT_ADMIN permission.
- As we only show associated picker in fulfillment and user with STOREFULFILLMENT_ADMIN permission gives the impression that user will picker in all facilities.
- Picker Association on users app should reflect on fulfillment app.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/b5f5a23f-07ba-439b-8fe0-891b9a84b443" />
<img width="480" height="270" alt="Screenshot from 2025-07-28 15-27-31" src="https://github.com/user-attachments/assets/72b6b267-02d9-4cf7-9bc5-759ea1c9b3ac" />


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/users#contribution-guideline)